### PR TITLE
Migrate cert viewer understandingwebpki.com to x509.io in demo 5/4/4

### DIFF
--- a/public/demos/5-Signer/4-various/4-validation-poc/script.php
+++ b/public/demos/5-Signer/4-various/4-validation-poc/script.php
@@ -52,7 +52,7 @@ function verifyAndDumpCertificate(
 
     $b64 = base64_encode($certificate->get(\SetaPDF_Signer_X509_Format::DER));
     echo '<a href="data:application/x-pem-file;base64,' . $b64 . '" download="certificate.crt">download</a> | ' .
-        '<a href="https://understandingwebpki.com/?cert=' . urlencode($b64) . '" target="_blank">show details</a><br/>';
+        '<a href="https://x509.io/?cert=' . urlencode($b64) . '" target="_blank">show details</a><br/>';
     echo 'Simple certificate dump:<br/>';
     echo '<div style="white-space: pre; height: 250px; overflow: auto;">' .
         print_r(openssl_x509_parse($certificate->get()), true) . '</div>';


### PR DESCRIPTION
Hello!

I found via GitHub global code search, that one of the demos in this repository uses https://understandingwebpki.com as an online certificate viewer, while it changed its home to https://x509.io some time ago, according to:
- https://twitter.com/rmhrisk/status/1721979059889168389
- https://github.com/PeculiarVentures/pv-certificates-viewer

I haven't found any contribution guidelines so opened PR with a URL update in a free form.
